### PR TITLE
Improved conversion

### DIFF
--- a/mpyc/runtime.py
+++ b/mpyc/runtime.py
@@ -530,14 +530,11 @@ class Runtime:
         x = await self.output(x)
         r = thresha.pseudorandom_share(ttype.field, m, self.pid, prfs, uci, n)
         for i in range(n):
-            x[i] = x[i].value - offset - r[i]
-        if issubclass(stype, sectypes.SecureFiniteField):
-            for i in range(n):
+            x[i] = x[i].value - r[i]
+            if issubclass(stype, sectypes.SecureFiniteField):
                 x[i] = self._mod(ttype(x[i]), stype.field.modulus)
-                if stype.field.is_signed and ttype.field.is_signed:
-                    is_neg = x[i] > stype.field.modulus >> 1
-                    x[i] = x[i] + is_neg * (ttype.field.modulus - stype.field.modulus)
-        elif d > 0:
+            x[i] = x[i] - offset
+        if d > 0 and not issubclass(stype, sectypes.SecureFiniteField):
             for i in range(n):
                 x[i] <<= d
         return x

--- a/tests/test_runtime.py
+++ b/tests/test_runtime.py
@@ -382,9 +382,11 @@ class Arithmetic(unittest.TestCase):
         y = mpc.convert(x, secfld263)
         self.assertEqual(mpc.run(mpc.output(y)), list(range(10)))
 
-        x = [secfld47s(i) for i in range(10)]
+        x = [secfld47s(i) for i in range(-5, 10)]
         y = mpc.convert(x, secfld37s)
-        self.assertEqual(mpc.run(mpc.output(y)), list(range(10)))
+        self.assertEqual(mpc.run(mpc.output(y)), list(range(-5, 10)))
+        y = mpc.convert(y, secfxp)
+        self.assertEqual(mpc.run(mpc.output(y)), list(range(-5, 10)))
 
         x = [secint(-100), secint(100)]
         y = mpc.convert(x, secfxp)


### PR DESCRIPTION
An earlier pull request fixed the conversion from SecFld to SecFxp/SecInt for signed secrets, but in a very inefficient way. It turns out that the fix could have been much easier and without need for a secure conversion.