### PR TITLE
some small changes to make mpyc compatible with oblif

### DIFF
--- a/mpyc/runtime.py
+++ b/mpyc/runtime.py
@@ -1432,9 +1432,10 @@ class Runtime:
         if isinstance(c, sectypes.SecureFixedPoint) and not c.integral:
             raise ValueError('condition must be integral')
 
-        if x is y:
+        if x is y:  # introduced for github.com/meilof/oblif
             return x
-        elif isinstance(x, list):
+
+        if isinstance(x, list):
             z = self._if_else_list(c, x, y)
         else:
             z = c * (x - y) + y

--- a/mpyc/runtime.py
+++ b/mpyc/runtime.py
@@ -1432,7 +1432,9 @@ class Runtime:
         if isinstance(c, sectypes.SecureFixedPoint) and not c.integral:
             raise ValueError('condition must be integral')
 
-        if isinstance(x, list):
+        if x is y:
+            return x
+        elif isinstance(x, list):
             z = self._if_else_list(c, x, y)
         else:
             z = c * (x - y) + y

--- a/mpyc/sectypes.py
+++ b/mpyc/sectypes.py
@@ -48,6 +48,14 @@ class SecureObject:
     def __bool__(self):
         """Use of secret-shared objects in Boolean expressions makes no sense."""
         raise TypeError('cannot use secure type in Boolean expressions')
+        
+    def __deepcopy__(self, memo):
+        """Lets secret-shared objects behave as immutable objects"""
+        return self
+    
+    def if_else(self, ifobject, elseobject):
+        """Allow to access secure selection from the guard object"""
+        return runtime.if_else(self, ifobject, elseobject)
 
 
 class SecureNumber(SecureObject):

--- a/mpyc/sectypes.py
+++ b/mpyc/sectypes.py
@@ -45,17 +45,20 @@ class SecureObject:
         else:
             self.share.set_result(v)
 
+    def __deepcopy__(self, memo):
+        """Let SecureObjects behave as immutable objects.
+
+        Introduced for github.com/meilof/oblif.
+        """
+        return self
+
     def __bool__(self):
         """Use of secret-shared objects in Boolean expressions makes no sense."""
         raise TypeError('cannot use secure type in Boolean expressions')
-        
-    def __deepcopy__(self, memo):
-        """Lets secret-shared objects behave as immutable objects"""
-        return self
-    
-    def if_else(self, ifobject, elseobject):
-        """Allow to access secure selection from the guard object"""
-        return runtime.if_else(self, ifobject, elseobject)
+
+    def if_else(self, x, y):
+        """Use SecureObject as condition for secure selection between x and y."""
+        return runtime.if_else(self, x, y)
 
 
 class SecureNumber(SecureObject):


### PR DESCRIPTION
These small changes make it possible to use mpyc together with oblif:

 - call if_else via the SecureObject so that no access to the runtime is needed
 - let if_else return directly if the if and else objects are the same
 - make SecureObjects immutable so that objects containing them can be efficiently deepcopied