### PR TITLE
Feat: return indicator vector from argmin and argmax

### DIFF
--- a/mpyc/runtime.py
+++ b/mpyc/runtime.py
@@ -10,7 +10,6 @@ import os
 import sys
 import time
 import datetime
-from dataclasses import dataclass
 import importlib.util
 import logging
 import math
@@ -2376,11 +2375,11 @@ def setup():
     return rt
 
 
-@dataclass
 class _BinaryNode:
-    value = None
-    left = None
-    right = None
+    def __init__(self, value=None, left=None, right=None):
+        self.value = value
+        self.left = left
+        self.right = right
 
 
 if os.getenv('READTHEDOCS') != 'True':

--- a/mpyc/runtime.py
+++ b/mpyc/runtime.py
@@ -1037,6 +1037,10 @@ class Runtime:
         if not as_vec:
             return self._argmax(x, key)
 
+        if n == 1:
+            stype = type(x[0][0]) if isinstance(x[0], list) else type(x[0])
+            return [stype(1)], x[0]
+
         bintree_path_to_max, max_ = self._argmax_as_bintree(x, key)
         return self._reverse_bintree_search(bintree_path_to_max), max_
 

--- a/tests/test_runtime.py
+++ b/tests/test_runtime.py
@@ -1,6 +1,7 @@
-import operator
 import math
+import operator
 import unittest
+
 import mpyc.gmpy as gmpy2
 from mpyc.runtime import mpc
 
@@ -328,9 +329,11 @@ class Arithmetic(unittest.TestCase):
             self.assertEqual(mpc.run(mpc.output(mpc.max(a, 0))), max(s[0], 0))
             self.assertEqual(mpc.run(mpc.output(mpc.max(0, b))), max(0, s[1]))
             self.assertEqual(mpc.run(mpc.output(list(mpc.min_max(a, b, c, d)))), [min(s), max(s)])
-            self.assertEqual(mpc.run(mpc.output(mpc.argmin([a, b, c, d])[0])), 1)
+            self.assertEqual(mpc.run(mpc.output(mpc.argmin([a, b, b, c, d])[0])), 1)
+            self.assertEqual(mpc.run(mpc.output(mpc.argmin([a, b, b, c, d], as_vec=True)[0])), [0, 1, 0, 0, 0])
             self.assertEqual(mpc.run(mpc.output(mpc.argmin([a, b], key=operator.neg)[1])), max(s))
-            self.assertEqual(mpc.run(mpc.output(mpc.argmax([a, b, c, d])[0])), 0)
+            self.assertEqual(mpc.run(mpc.output(mpc.argmax([a, a, b, c, d])[0])), 0)
+            self.assertEqual(mpc.run(mpc.output(mpc.argmax([a, a, b, c, d], as_vec=True)[0])), [1, 0, 0, 0, 0])
             self.assertEqual(mpc.run(mpc.output(mpc.argmax([a, b], key=operator.neg)[1])), min(s))
 
             self.assertEqual(mpc.run(mpc.output(secfxp(5) % 2)), 1)
@@ -521,8 +524,10 @@ class Arithmetic(unittest.TestCase):
             self.assertEqual(mpc.run(mpc.output(mpc.find([secnum(1)], 1, f=lambda i: i))), 0)
         self.assertEqual(mpc.run(mpc.output(mpc.min(secint(i) for i in range(-1, 2, 1)))), -1)
         self.assertEqual(mpc.run(mpc.output(mpc.argmin(secint(i) for i in range(-1, 2, 1))[0])), 0)
+        self.assertEqual(mpc.run(mpc.output(mpc.argmin((secint(i) for i in range(-1, 2, 1)), as_vec=True)[0])), [1, 0, 0])
         self.assertEqual(mpc.run(mpc.output(mpc.max(secfxp(i) for i in range(-1, 2, 1)))), 1)
         self.assertEqual(mpc.run(mpc.output(mpc.argmax(secfxp(i) for i in range(-1, 2, 1))[0])), 2)
+        self.assertEqual(mpc.run(mpc.output(mpc.argmax((secfxp(i) for i in range(-1, 2, 1)), as_vec=True)[0])), [0, 0, 1])
         self.assertEqual(mpc.run(mpc.output(list(mpc.min_max(map(secfxp, range(5)))))), [0, 4])
         x = (secint(i) for i in range(-3, 3))
         s = [0, -1, 1, -2, 2, -3]

--- a/tests/test_runtime.py
+++ b/tests/test_runtime.py
@@ -1,7 +1,6 @@
-import math
 import operator
+import math
 import unittest
-
 import mpyc.gmpy as gmpy2
 from mpyc.runtime import mpc
 


### PR DESCRIPTION
Adds the possibility to return an indicator vector from argmin and argmax rather than the index. The number of rounds is still logarithmic. Tests are included.

Core workings: keep track of the binary search to the maximum, then backtrack this path. Tests are included.

Additional improvement: `_argmin` was removed.

Note: A slightly simpler but less efficient version of this algorithm is also available, please let me know if you are interested.