### PR TITLE
upgrade pip version within the build jobs

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,8 +3,10 @@ language: python
 python:
     - 3.8
     - 3.9
-#    - 3.10
+    - 3.10
     - pypy3.8-7.3.9
-install: pip install codecov numpy
+install:
+    - pip install --upgrade pip
+    - pip install codecov numpy
 script: coverage run --source mpyc -m unittest discover tests
 after_success: codecov


### PR DESCRIPTION
This should resolve the issues of failing builds for python version `3.10.x`