### PR TITLE
Implement np_shuffle

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -99,3 +99,6 @@ ENV/
 
 # mypy
 .mypy_cache/
+
+# vscode
+.vscode

--- a/mpyc/random.py
+++ b/mpyc/random.py
@@ -373,7 +373,7 @@ def np_shuffle(a, axis=None):
     if axis is None:
         axis = 0
 
-    if axis >= len(a.shape):
+    if axis >= len(a.shape) or axis <0:
         raise ValueError("Invalid axis")
 
     x = runtime.np_copy(a)

--- a/mpyc/random.py
+++ b/mpyc/random.py
@@ -364,7 +364,7 @@ async def np_random_unit_vector(sectype, n):
     return u
 
 
-def np_shuffle(a, axis=None):
+async def np_shuffle(a, axis=None):
     """Shuffle numpy-like array x secretly in-place, and return None.
 
     Given array x may contain public or secret elements.
@@ -401,4 +401,5 @@ def np_shuffle(a, axis=None):
     if axis != 0:
         x = runtime.np_transpose(x)
 
+    x = await runtime.gather(x)
     runtime.np_update(a, range(a.shape[0]), x)

--- a/mpyc/random.py
+++ b/mpyc/random.py
@@ -322,3 +322,79 @@ def uniform(sectype, a, b):
 
     s = math.copysign(1, b - a)
     return a + _randbelow(sectype, round(abs(a - b) * 2**f)) * s * 2**-f
+
+
+@asyncoro.mpc_coro
+async def np_random_unit_vector(sectype, n):
+    """Uniformly random secret rotation of [1] + [0]*(n-1).
+
+    Expected number of secret random bits needed is ceil(log_2 n) + c,
+    with c a small constant, c < 3.
+    """
+
+    if issubclass(sectype, runtime.SecureObject):
+        await runtime.returnType((sectype.array, True, (n,)))
+    else:
+        await runtime.returnType(asyncoro.Future)
+
+    if n == 1:
+        return runtime.np_fromlist([sectype(1)])
+
+    b = n - 1
+    k = b.bit_length()
+    x = runtime.np_random_bits(sectype, k)
+
+    i = k - 1
+    u = runtime.np_fromlist([x[i], 1 - x[i]])
+    while i:
+        i -= 1
+        if (b >> i) & 1:
+            v = x[i] * u
+            v = runtime.np_hstack((v, u - v))
+            u = v
+        elif await runtime.output(u[0] * x[i]):  # TODO: mul_public
+            # restart, keeping unused secret random bits x[:i]
+            x = runtime.np_hstack((x[:i], np_random_unit_vector(sectype, k - i)))
+            i = k - 1
+            u = runtime.np_fromlist([x[i], 1 - x[i]])
+        else:
+            v = x[i] * u[1:]
+            v = runtime.np_hstack((v, u[1:] - v))
+            u = runtime.np_hstack((u[:1], v))
+    return u
+
+
+def np_shuffle(a, axis=None):
+    """Shuffle numpy-like array x secretly in-place, and return None.
+
+    Given array x may contain public or secret elements.
+    """
+    sectype = type(a).sectype
+    if axis is None:
+        axis = 0
+
+    if axis >= len(a.shape):
+        raise ValueError("Invalid axis")
+
+    x = runtime.np_copy(a)
+
+    if axis != 0:
+        x = runtime.np_swapaxes(x, 0, axis)
+
+    n = x.shape[0]
+
+    for i in range(n - 1):
+        u = runtime.np_transpose(np_random_unit_vector(sectype, n - i))
+        x_u = runtime.np_matmul(u, x[i:])
+        if len(x.shape) > 1:
+            d = runtime.np_outer(u, (x[i] - x_u))
+            x = runtime.np_vstack((x[:i, ...], runtime.np_add(x[i:, ...], d)))
+        else:
+            d = u * (x[i] - x_u)
+            x = runtime.np_hstack((x[:i, ...], runtime.np_add(x[i:, ...], d)))
+        runtime.np_update(x, i, x_u)
+
+    if axis != 0:
+        x = runtime.np_swapaxes(x, 0, axis)
+
+    runtime.np_update(a, range(a.shape[0]), x)

--- a/mpyc/random.py
+++ b/mpyc/random.py
@@ -332,10 +332,7 @@ async def np_random_unit_vector(sectype, n):
     with c a small constant, c < 3.
     """
 
-    if issubclass(sectype, runtime.SecureObject):
-        await runtime.returnType((sectype.array, True, (n,)))
-    else:
-        await runtime.returnType(asyncoro.Future)
+    await runtime.returnType((sectype.array, True, (n,)))
 
     if n == 1:
         return runtime.np_fromlist([sectype(1)])

--- a/tests/test_random.py
+++ b/tests/test_random.py
@@ -1,6 +1,6 @@
 import unittest
 from mpyc.runtime import mpc
-from mpyc.random import (getrandbits, randrange, random_unit_vector, randint,
+from mpyc.random import (getrandbits, randrange, random_unit_vector, np_random_unit_vector, randint,
                          shuffle, np_shuffle, random_permutation, random_derangement,
                          choice, choices, sample, random, uniform)
 from mpyc.numpy import np
@@ -19,6 +19,8 @@ class Arithmetic(unittest.TestCase):
         self.assertLessEqual(a, 2**10 - 1)
 
         x = mpc.run(mpc.output(random_unit_vector(secint, 4)))
+        self.assertEqual(sum(x), 1)
+        x = mpc.run(mpc.output(np_random_unit_vector(secint, 4)))
         self.assertEqual(sum(x), 1)
 
         a = mpc.run(mpc.output(randrange(secint, 37)))  # French roulette
@@ -86,6 +88,11 @@ class Arithmetic(unittest.TestCase):
         x = mpc.run(mpc.output(x))
         self.assertSetEqual(set(x), set(np.arange(8)))
 
+        x = secint.array(np.array([np.arange(8)]))
+        mpc.run(np_shuffle(x))
+        x = mpc.run(mpc.output(x))
+        self.assertTrue((x == np.array([np.arange(8)])).all())
+
         x_init = np.arange(8).reshape(2,4)
         x = secint.array(x_init)
         mpc.run(np_shuffle(x))
@@ -101,6 +108,10 @@ class Arithmetic(unittest.TestCase):
         with self.assertRaises(ValueError):
             mpc.run(np_shuffle(x, 3))
 
+        x = secint.array(np.ones((8,8,8)))
+        with self.assertRaises(ValueError):
+            mpc.run(np_shuffle(x))
+
 
     def test_secfxp(self):
         secfxp = mpc.SecFxp()
@@ -111,6 +122,8 @@ class Arithmetic(unittest.TestCase):
         self.assertLessEqual(int(a), 2**10 - 1)
 
         x = mpc.run(mpc.output(random_unit_vector(secfxp, 3)))
+        self.assertEqual(int(sum(x)), 1)
+        x = mpc.run(mpc.output(np_random_unit_vector(secfxp, 3)))
         self.assertEqual(int(sum(x)), 1)
 
         x = mpc.run(mpc.output(random_permutation(secfxp, range(1, 9))))
@@ -159,6 +172,8 @@ class Arithmetic(unittest.TestCase):
         self.assertIn(a, [0, 1, 2])
         x = mpc.run(mpc.output(random_unit_vector(secfld, 2)))
         self.assertEqual(int(sum(x)), 1)
+        x = mpc.run(mpc.output(np_random_unit_vector(secfld, 2)))
+        self.assertEqual(int(sum(x)), 1)
         x = mpc.run(mpc.output(random_permutation(secfld, range(1, 9))))
         self.assertSetEqual(set(map(int, x)), set(range(1, 9)))
         x = mpc.run(mpc.output(random_derangement(secfld, range(2))))
@@ -175,6 +190,8 @@ class Arithmetic(unittest.TestCase):
         a = mpc.run(mpc.output(randint(secfld, -1, 1)))
         self.assertIn(a, [-1, 0, 1])
         x = mpc.run(mpc.output(random_unit_vector(secfld, 1)))
+        self.assertEqual(int(sum(x)), 1)
+        x = mpc.run(mpc.output(np_random_unit_vector(secfld, 1)))
         self.assertEqual(int(sum(x)), 1)
         x = mpc.run(mpc.output(random_permutation(secfld, range(1, 9))))
         self.assertSetEqual(set(map(int, x)), set(range(1, 9)))

--- a/tests/test_random.py
+++ b/tests/test_random.py
@@ -20,8 +20,6 @@ class Arithmetic(unittest.TestCase):
 
         x = mpc.run(mpc.output(random_unit_vector(secint, 4)))
         self.assertEqual(sum(x), 1)
-        x = mpc.run(mpc.output(np_random_unit_vector(secint, 4)))
-        self.assertEqual(sum(x), 1)
 
         a = mpc.run(mpc.output(randrange(secint, 37)))  # French roulette
         self.assertGreaterEqual(a, 0)
@@ -112,6 +110,23 @@ class Arithmetic(unittest.TestCase):
         with self.assertRaises(ValueError):
             mpc.run(np_shuffle(x))
 
+    @unittest.skipIf(not np, 'NumPy not available or inside MPyC disabled')
+    def test_np_random_unit_vector(self):
+        secint = mpc.SecInt()
+        x = mpc.run(mpc.output(np_random_unit_vector(secint, 4)))
+        self.assertEqual(sum(x), 1)
+
+        secfxp = mpc.SecFxp()
+        x = mpc.run(mpc.output(np_random_unit_vector(secfxp, 3)))
+        self.assertEqual(int(sum(x)), 1)
+
+        secfld = mpc.SecFld(256)
+        x = mpc.run(mpc.output(np_random_unit_vector(secfld, 2)))
+        self.assertEqual(int(sum(x)), 1)
+
+        secfld = mpc.SecFld(257)
+        x = mpc.run(mpc.output(np_random_unit_vector(secfld, 1)))
+        self.assertEqual(int(sum(x)), 1)
 
     def test_secfxp(self):
         secfxp = mpc.SecFxp()
@@ -122,8 +137,6 @@ class Arithmetic(unittest.TestCase):
         self.assertLessEqual(int(a), 2**10 - 1)
 
         x = mpc.run(mpc.output(random_unit_vector(secfxp, 3)))
-        self.assertEqual(int(sum(x)), 1)
-        x = mpc.run(mpc.output(np_random_unit_vector(secfxp, 3)))
         self.assertEqual(int(sum(x)), 1)
 
         x = mpc.run(mpc.output(random_permutation(secfxp, range(1, 9))))
@@ -172,8 +185,6 @@ class Arithmetic(unittest.TestCase):
         self.assertIn(a, [0, 1, 2])
         x = mpc.run(mpc.output(random_unit_vector(secfld, 2)))
         self.assertEqual(int(sum(x)), 1)
-        x = mpc.run(mpc.output(np_random_unit_vector(secfld, 2)))
-        self.assertEqual(int(sum(x)), 1)
         x = mpc.run(mpc.output(random_permutation(secfld, range(1, 9))))
         self.assertSetEqual(set(map(int, x)), set(range(1, 9)))
         x = mpc.run(mpc.output(random_derangement(secfld, range(2))))
@@ -190,8 +201,6 @@ class Arithmetic(unittest.TestCase):
         a = mpc.run(mpc.output(randint(secfld, -1, 1)))
         self.assertIn(a, [-1, 0, 1])
         x = mpc.run(mpc.output(random_unit_vector(secfld, 1)))
-        self.assertEqual(int(sum(x)), 1)
-        x = mpc.run(mpc.output(np_random_unit_vector(secfld, 1)))
         self.assertEqual(int(sum(x)), 1)
         x = mpc.run(mpc.output(random_permutation(secfld, range(1, 9))))
         self.assertSetEqual(set(map(int, x)), set(range(1, 9)))

--- a/tests/test_random.py
+++ b/tests/test_random.py
@@ -1,8 +1,9 @@
 import unittest
 from mpyc.runtime import mpc
 from mpyc.random import (getrandbits, randrange, random_unit_vector, randint,
-                         shuffle, random_permutation, random_derangement,
+                         shuffle, np_shuffle, random_permutation, random_derangement,
                          choice, choices, sample, random, uniform)
+from mpyc.numpy import np
 
 
 class Arithmetic(unittest.TestCase):
@@ -76,6 +77,29 @@ class Arithmetic(unittest.TestCase):
         self.assertGreaterEqual(min(x) // 1000, 1000)
         self.assertLessEqual(max(x) // 1000, 1009)
         self.assertEqual(sum(x) % 1000, 0)
+
+    @unittest.skipIf(not np, 'NumPy not available or inside MPyC disabled')
+    def test_np_shuffle(self):
+        secint = mpc.SecInt()
+        x = secint.array(np.arange(8))
+        np_shuffle(x)
+        x = mpc.run(mpc.output(x))
+        self.assertSetEqual(set(x), set(np.arange(8)))
+
+        x_init = np.arange(8).reshape(2,4)
+        x = secint.array(x_init)
+        np_shuffle(x)
+        x = mpc.run(mpc.output(x))
+        self.assertIn(set(x[0,:]), [set(x_init[i,:]) for i in range(x_init.shape[0])])
+
+        x = secint.array(x_init)
+        np_shuffle(x, axis=1)
+        x = mpc.run(mpc.output(x))
+        self.assertIn(set(x[:,0]), [set(x_init[:,j]) for j in range(x_init.shape[1])])
+
+        x = secint.array(x_init)
+        self.assertRaises(ValueError, np_shuffle, x, 3)
+
 
     def test_secfxp(self):
         secfxp = mpc.SecFxp()

--- a/tests/test_random.py
+++ b/tests/test_random.py
@@ -82,23 +82,24 @@ class Arithmetic(unittest.TestCase):
     def test_np_shuffle(self):
         secint = mpc.SecInt()
         x = secint.array(np.arange(8))
-        np_shuffle(x)
+        mpc.run(np_shuffle(x))
         x = mpc.run(mpc.output(x))
         self.assertSetEqual(set(x), set(np.arange(8)))
 
         x_init = np.arange(8).reshape(2,4)
         x = secint.array(x_init)
-        np_shuffle(x)
+        mpc.run(np_shuffle(x))
         x = mpc.run(mpc.output(x))
         self.assertIn(set(x[0,:]), [set(x_init[i,:]) for i in range(x_init.shape[0])])
 
         x = secint.array(x_init)
-        np_shuffle(x, axis=1)
+        mpc.run(np_shuffle(x, axis=1))
         x = mpc.run(mpc.output(x))
         self.assertIn(set(x[:,0]), [set(x_init[:,j]) for j in range(x_init.shape[1])])
 
         x = secint.array(x_init)
-        self.assertRaises(ValueError, np_shuffle, x, 3)
+        with self.assertRaises(ValueError):
+            mpc.run(np_shuffle(x, 3))
 
 
     def test_secfxp(self):


### PR DESCRIPTION
Implements the shuffle coroutine for numpy-like arrays.

This is a copy of #49 because I moved the commits to a secondary branch to clean up my master branch. In parallel, I am closing #49.

This cleaning was necessary to prepare my repo for other PRs. 