### PR TITLE
Fix the inconsistent integral property in np_sum

### DIFF
--- a/mpyc/runtime.py
+++ b/mpyc/runtime.py
@@ -2909,9 +2909,15 @@ class Runtime:
             else:
                 shape = tuple(s for i, s in enumerate(a.shape) if i not in axes)
         if shape == ():
-            await self.returnType(sectype)
+            if isinstance(a, self.SecureFixedPointArray):
+                await self.returnType((sectype, a.integral))
+            else:
+                await self.returnType(sectype)
         else:
-            await self.returnType((type(a), shape))
+            if isinstance(a, self.SecureFixedPointArray):
+                await self.returnType((type(a), a.integral, shape))
+            else:
+                await self.returnType((type(a), shape))
         a, initial = await self.gather(a, initial)
         return np.sum(a, axis=axis, keepdims=keepdims, initial=initial.value)
         # TODO: handle switch from initial (field elt) to initial.value inside finfields.py

--- a/mpyc/runtime.py
+++ b/mpyc/runtime.py
@@ -2910,14 +2910,15 @@ class Runtime:
                 shape = tuple(s for i, s in enumerate(a.shape) if i not in axes)
         if shape == ():
             if isinstance(a, self.SecureFixedPointArray):
-                await self.returnType((sectype, a.integral))
+                rettype = (sectype, a.integral)
             else:
-                await self.returnType(sectype)
+                rettype = sectype
         else:
             if isinstance(a, self.SecureFixedPointArray):
-                await self.returnType((type(a), a.integral, shape))
+                rettype = (type(a), a.integral, shape)
             else:
-                await self.returnType((type(a), shape))
+                rettype = (type(a), shape)
+        await self.returnType(rettype)
         a, initial = await self.gather(a, initial)
         return np.sum(a, axis=axis, keepdims=keepdims, initial=initial.value)
         # TODO: handle switch from initial (field elt) to initial.value inside finfields.py

--- a/tests/test_runtime.py
+++ b/tests/test_runtime.py
@@ -349,7 +349,7 @@ class Arithmetic(unittest.TestCase):
         self.assertEqual(np.amax(c2).integral, True)
         self.assertEqual(np.amax(c2, axis=0).integral, True)
         self.assertEqual(np.amax(c1).integral, False)
-        self.assertEqual(np.amax(c1, axis=0).integral, False)    
+        self.assertEqual(np.amax(c1, axis=0).integral, False)
 
         self.assertEqual(np.argmin(c2).integral, True)
         self.assertEqual(np.argmin(c2, axis=0).integral, True)
@@ -358,7 +358,7 @@ class Arithmetic(unittest.TestCase):
         self.assertEqual(np.argmax(c2).integral, True)
         self.assertEqual(np.argmax(c2, axis=0).integral, True)
         self.assertEqual(np.argmax(c1).integral, True)
-        self.assertEqual(np.argmax(c1, axis=0).integral, True)    
+        self.assertEqual(np.argmax(c1, axis=0).integral, True)
 
     @unittest.skipIf(not np, 'NumPy not available or inside MPyC disabled')
     def test_secfld_array(self):

--- a/tests/test_runtime.py
+++ b/tests/test_runtime.py
@@ -325,6 +325,11 @@ class Arithmetic(unittest.TestCase):
         self.assertEqual(np.vstack((c1, c1)).integral, False)
         self.assertEqual(np.vstack((c2, c2)).integral, True)
 
+        self.assertEqual(np.sum(c2).integral, True)
+        self.assertEqual(np.sum(c2, axis=0).integral, True)
+        self.assertEqual(np.sum(c1).integral, False)
+        self.assertEqual(np.sum(c1, axis=0).integral, False)
+
     @unittest.skipIf(not np, 'NumPy not available or inside MPyC disabled')
     def test_secfld_array(self):
         np.assertEqual = np.testing.assert_array_equal

--- a/tests/test_runtime.py
+++ b/tests/test_runtime.py
@@ -330,6 +330,36 @@ class Arithmetic(unittest.TestCase):
         self.assertEqual(np.sum(c1).integral, False)
         self.assertEqual(np.sum(c1, axis=0).integral, False)
 
+        self.assertEqual(mpc.np_sgn(c1).integral, True)
+        self.assertEqual(mpc.np_sgn(c2).integral, True)
+        self.assertEqual(np.absolute(c1).integral, False)
+        self.assertEqual(np.absolute(c2).integral, True)
+
+        self.assertEqual(np.minimum(c1, c2).integral, False)
+        self.assertEqual(np.minimum(c1, c1).integral, False)
+        self.assertEqual(np.minimum(c2, c2).integral, True)
+        self.assertEqual(np.maximum(c1, c2).integral, False)
+        self.assertEqual(np.maximum(c1, c1).integral, False)
+        self.assertEqual(np.maximum(c2, c2).integral, True)
+
+        self.assertEqual(np.amin(c2).integral, True)
+        self.assertEqual(np.amin(c2, axis=0).integral, True)
+        self.assertEqual(np.amin(c1).integral, False)
+        self.assertEqual(np.amin(c1, axis=0).integral, False)
+        self.assertEqual(np.amax(c2).integral, True)
+        self.assertEqual(np.amax(c2, axis=0).integral, True)
+        self.assertEqual(np.amax(c1).integral, False)
+        self.assertEqual(np.amax(c1, axis=0).integral, False)    
+
+        self.assertEqual(np.argmin(c2).integral, True)
+        self.assertEqual(np.argmin(c2, axis=0).integral, True)
+        self.assertEqual(np.argmin(c1).integral, True)
+        self.assertEqual(np.argmin(c1, axis=0).integral, True)
+        self.assertEqual(np.argmax(c2).integral, True)
+        self.assertEqual(np.argmax(c2, axis=0).integral, True)
+        self.assertEqual(np.argmax(c1).integral, True)
+        self.assertEqual(np.argmax(c1, axis=0).integral, True)    
+
     @unittest.skipIf(not np, 'NumPy not available or inside MPyC disabled')
     def test_secfld_array(self):
         np.assertEqual = np.testing.assert_array_equal


### PR DESCRIPTION
This PR fixes the inconsistent integral property in `np_sum`. It also adds unit tests for other basic array operations: min, max, argmin, argmax, etc.

See #67 for more details. 