### PR TITLE
Introduce np_lsb() function to runtime

### DIFF
--- a/mpyc/runtime.py
+++ b/mpyc/runtime.py
@@ -1701,7 +1701,7 @@ class Runtime:
 
     @asyncoro.mpc_coro
     async def np_lsb(self, a):
-        """Compute least significant bits of values in array a""" # a la [ST06]
+        """Compute least significant bits of (elements of) a."""  # a la [ST06]
         await self.returnType((type(a), True, a.shape))
         stype = a.sectype
         Zp = stype.field
@@ -1709,21 +1709,16 @@ class Runtime:
         k = self.options.sec_param
         f = stype.frac_length
 
-        b = self.np_random_bits(stype, len(a))
+        b = self.np_random_bits(stype, a.size).reshape(*a.shape)
         a, b = await self.gather(a, b)
         if f:
             b >>= f
-
-        rs = self._np_randoms(Zp, len(a), bound = 1 << (l + k - 1))
+        r = self._np_randoms(Zp, a.size, 1 << (l + k - 1)).reshape(*a.shape)
         if self.options.no_prss:
-            rs = (await rs)[0]
-
-        r = b + 2 * rs
-        c = await self.output(a + r + 2**l)  # denoted by 'y' in [ST06]
-
-        c0 = (c.value & 1)
-        x = (c0 + b) - 2 * (c0 * b) # xor
-
+            r = (await r)[0]
+        r = r.value
+        c = await self.output(a + ((1<<l) + (r << 1) + b.value))
+        x = np.where(c.value & 1, 1 - b, b)  # xor
         if f:
             x <<= f
         return x

--- a/tests/test_runtime.py
+++ b/tests/test_runtime.py
@@ -129,6 +129,7 @@ class Arithmetic(unittest.TestCase):
         a *= 2
         c *= 2
         np.assertEqual(mpc.run(mpc.output(c)), a)
+        np.assertEqual(mpc.run(mpc.output(mpc.np_lsb(c))), a.value % 2)
         a /= 2
         c /= 2
         np.assertEqual(mpc.run(mpc.output(c)), a)
@@ -327,6 +328,7 @@ class Arithmetic(unittest.TestCase):
         np.assertEqual(mpc.run(mpc.output(c * 2.5)), a * 2.5)
         np.assertEqual(mpc.run(mpc.output(c / secfxp.field(2))), a / 2)
         np.assertEqual(mpc.run(mpc.output(c / secfxp.field.array([2]))), a / 2)
+        np.assertEqual(mpc.run(mpc.output(mpc.np_lsb(c))), a % 2**-(secfxp.frac_length-1))
 
         # NB: NumPy dispatcher converts np.int8 to int
         np.assertEqual(mpc.run(mpc.output(c * np.int8(2))), a * 2)
@@ -481,6 +483,8 @@ class Arithmetic(unittest.TestCase):
 
         self.assertEqual(mpc.np_sgn(c1).integral, True)
         self.assertEqual(mpc.np_sgn(c2).integral, True)
+        self.assertEqual(mpc.np_lsb(c1).integral, True)
+        self.assertEqual(mpc.np_lsb(c2).integral, True)
         self.assertEqual(np.absolute(c1).integral, False)
         self.assertEqual(np.absolute(c2).integral, True)
 


### PR DESCRIPTION
This PR introduces the ```np_lsb()``` function to the MPyC runtime, to allow for better vectorization of operations.

Performance between the new ```np_lsb()``` and existing ```lsb()``` functions was measured on a list of random integers, e.g.:

```
ex = mpc.np_lsb(v)
```
compared to

```
ex = mpc.np_fromlist([mpc.lsb(x) for x in v])
```

For an input size of 10.000 integers of bit-length 32 and 3 parties, the new implementation takes 0:00:00.215, while the existing non-numpy implementation takes 0:00:06.765 on my computer. E.g. the new version is 30x faster on my system. This occurs primarily for large input sizes; for smaller input sizes, the difference is small.